### PR TITLE
Fix salary slip tax slab defaults

### DIFF
--- a/payroll_indonesia/override/salary_slip/controller.py
+++ b/payroll_indonesia/override/salary_slip/controller.py
@@ -57,15 +57,15 @@ class IndonesiaPayrollSalarySlip(SalarySlip):
         Returns:
             frappe._dict: Dummy tax slab object
         """
-        return frappe._dict({"allow_tax_exemption": 0})
+        return frappe._dict({"allow_tax_exemption": 0, "slabs": []})
 
     def ensure_tax_slab(self) -> None:
-        """Ensure ``self.tax_slab`` is a mapping with ``allow_tax_exemption``."""
+        """Ensure ``self.tax_slab`` is a mapping with ``allow_tax_exemption`` and ``slabs``."""
         from collections.abc import Mapping
 
         tax_slab = getattr(self, "tax_slab", None)
-        if not isinstance(tax_slab, Mapping):
-            self.tax_slab = frappe._dict({"allow_tax_exemption": 0})
+        if not isinstance(tax_slab, Mapping) or "slabs" not in tax_slab:
+            self.tax_slab = frappe._dict({"allow_tax_exemption": 0, "slabs": []})
 
     def validate(self):
         """Validate salary slip ensuring tax slab compatibility."""
@@ -231,7 +231,8 @@ class IndonesiaPayrollSalarySlip(SalarySlip):
             self.pph21 = pph21_component.amount
         else:
             result = tax_calc.calculate_monthly_pph_progressive(self)
-            pph21_component.amount = result.get("monthly_tax", 0.0)            self.pph21 = pph21_component.amount
+            pph21_component.amount = result.get("monthly_tax", 0.0)
+            self.pph21 = pph21_component.amount
 
     def calculate_net_pay(self, *args, **kwargs):
         """Ensure tax slab before net pay calculation."""

--- a/payroll_indonesia/payroll_indonesia/tests/test_tax_slab_validation.py
+++ b/payroll_indonesia/payroll_indonesia/tests/test_tax_slab_validation.py
@@ -1,6 +1,5 @@
 import sys
 import types
-import importlib
 from unittest.mock import MagicMock
 
 
@@ -15,6 +14,24 @@ def setup_frappe_stub():
 
     frappe.db = types.SimpleNamespace()
     frappe.get_cached_doc = MagicMock(return_value=types.SimpleNamespace(tax_calculation_method="PROGRESSIVE", use_ter=0))
+
+    utils = types.ModuleType("frappe.utils")
+    utils.flt = float
+    utils.getdate = lambda *a, **k: None
+    utils.cint = int
+    frappe.utils = utils
+    sys.modules["frappe.utils"] = utils
+
+    model_module = types.ModuleType("frappe.model")
+    document_module = types.ModuleType("frappe.model.document")
+
+    class Document:
+        pass
+
+    document_module.Document = Document
+
+    sys.modules["frappe.model"] = model_module
+    sys.modules["frappe.model.document"] = document_module
 
     sys.modules["frappe"] = frappe
     return frappe
@@ -42,13 +59,36 @@ def setup_salary_slip_stub():
     sys.modules["hrms.payroll.doctype.salary_slip"] = ss_pkg
     sys.modules["hrms.payroll.doctype.salary_slip.salary_slip"] = ss_module
 
+    # stub dependencies required by controller
+    override_pkg = types.ModuleType("payroll_indonesia.override")
+    override_pkg.__path__ = []
+    salary_slip_pkg = types.ModuleType("payroll_indonesia.override.salary_slip")
+    salary_slip_pkg.__path__ = []
+    sys.modules["payroll_indonesia.override"] = override_pkg
+    sys.modules["payroll_indonesia.override.salary_slip"] = salary_slip_pkg
+
+    tax_calc_module = types.ModuleType("payroll_indonesia.override.salary_slip.tax_calculator")
+    sys.modules["payroll_indonesia.override.salary_slip.tax_calculator"] = tax_calc_module
+
+    utils_module = types.ModuleType("payroll_indonesia.payroll_indonesia.utils")
+    utils_module.get_status_pajak = lambda *a, **k: ""
+    utils_module.get_ptkp_to_ter_mapping = lambda: {}
+    utils_module.get_ter_rate = lambda *a, **k: 0
+    sys.modules["payroll_indonesia.payroll_indonesia.utils"] = utils_module
+
 
 
 def test_validate_sets_default_tax_slab(monkeypatch):
     frappe = setup_frappe_stub()
     setup_salary_slip_stub()
 
-    controller = importlib.import_module("payroll_indonesia.override.salary_slip.controller")
+    import importlib.util
+    from pathlib import Path
+
+    controller_path = Path(__file__).resolve().parents[2] / "override" / "salary_slip" / "controller.py"
+    spec = importlib.util.spec_from_file_location("controller", controller_path)
+    controller = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(controller)
     Slip = controller.IndonesiaPayrollSalarySlip
 
     slip = Slip()
@@ -56,8 +96,10 @@ def test_validate_sets_default_tax_slab(monkeypatch):
     # should not raise
     Slip.validate(slip)
     assert getattr(slip.tax_slab, "allow_tax_exemption") == 0
+    assert getattr(slip.tax_slab, "slabs") == []
 
     slip.tax_slab = "invalid"
     Slip.validate(slip)
     assert getattr(slip.tax_slab, "allow_tax_exemption") == 0
+    assert getattr(slip.tax_slab, "slabs") == []
 


### PR DESCRIPTION
## Summary
- return empty income tax slab and update ensure_tax_slab logic
- expand stub setup in tax_slab_validation test
- verify ensure_tax_slab handles invalid values

## Testing
- `pytest payroll_indonesia/payroll_indonesia/tests/test_tax_slab_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e630a81348333b1df1a6fbcc48ea8