### PR TITLE
Refactor tax summary update

### DIFF
--- a/payroll_indonesia/override/salary_slip_functions.py
+++ b/payroll_indonesia/override/salary_slip_functions.py
@@ -183,7 +183,7 @@ def update_component_amount(doc, method: Optional[str] = None) -> None:
         logger.exception(f"Error updating component amounts for {doc.name}: {e}")
 
     # Update tax summary
-    update_tax_summary(doc)
+    update_tax_summary(doc.name)
 
     # Update totals after modifying components
     try:
@@ -533,13 +533,15 @@ def _get_or_create_tax_row(slip) -> Tuple[Any, Any]:
     return row, summary
 
 
-def update_tax_summary(slip) -> None:
+def update_tax_summary(slip_name: str) -> None:
     """
     Update Employee Tax Summary with salary slip data.
 
     Args:
-        slip: The Salary Slip document
+        slip_name: Name of the Salary Slip document
     """
+    slip = frappe.get_doc("Salary Slip", slip_name)
+
     if not slip.employee:
         return
 
@@ -598,7 +600,7 @@ def enqueue_tax_summary_update(doc) -> None:
             queue="long",
             job_name=f"tax_summary_update_{doc.name}",
             enqueue_after_commit=True,
-            slip=doc,
+            slip_name=doc.name,
         )
     except Exception:
         logger.exception("Failed to enqueue tax summary update")


### PR DESCRIPTION
## Summary
- refactor `enqueue_tax_summary_update` to enqueue using slip name
- adjust `update_tax_summary` to accept `slip_name` and fetch the document
- call `update_tax_summary` with the slip name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7555f4d88333a6de3a35ac8fb63a