### PR TITLE
Refactor BPJS tests into doctype modules

### DIFF
--- a/payroll_indonesia/doctype/bpjs_account_mapping/__init__.py
+++ b/payroll_indonesia/doctype/bpjs_account_mapping/__init__.py
@@ -1,1 +1,2 @@
-# This file marks the BPJS Account Mapping doctype directory as a Python package
+# Expose BPJS Account Mapping tests
+from . import test_bpjs_account_mapping  # noqa: F401

--- a/payroll_indonesia/doctype/bpjs_account_mapping/test_bpjs_account_mapping.py
+++ b/payroll_indonesia/doctype/bpjs_account_mapping/test_bpjs_account_mapping.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import unittest
+import pytest
+
+frappe = pytest.importorskip("frappe")
+from frappe.utils import add_months, getdate
+
+from ...bpjs_account_mapping import bpjs_account_mapping as mapping
+
+
+class TestBPJSAccountMapping(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.company = frappe.get_doc({
+            "doctype": "Company",
+            "company_name": "BPJS Mapping Test Co",
+            "abbr": "BMT",
+            "default_currency": "IDR",
+            "country": "Indonesia",
+        })
+        if not frappe.db.exists("Company", cls.company.name):
+            cls.company.insert()
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.db.rollback()
+
+    def test_create_and_get_mapping(self):
+        mapping_name = mapping.create_default_mapping(self.company.name)
+        self.assertTrue(mapping_name)
+
+        result = mapping.get_mapping_for_company(self.company.name)
+        self.assertEqual(result["company"], self.company.name)
+        self.assertIn("payable_account", result)
+

--- a/payroll_indonesia/doctype/bpjs_payment_summary/__init__.py
+++ b/payroll_indonesia/doctype/bpjs_payment_summary/__init__.py
@@ -1,1 +1,2 @@
-
+# Expose BPJS Payment Summary tests
+from . import test_bpjs_payment_summary  # noqa: F401

--- a/payroll_indonesia/doctype/bpjs_payment_summary/test_bpjs_payment_summary.py
+++ b/payroll_indonesia/doctype/bpjs_payment_summary/test_bpjs_payment_summary.py
@@ -7,7 +7,7 @@ import pytest
 
 frappe = pytest.importorskip("frappe")
 from frappe.utils import getdate, add_months, get_first_day, get_last_day, flt, add_days
-from payroll_indonesia.override.salary_slip.tax_calculator import calculate_tax_components
+from ...override.salary_slip.tax_calculator import calculate_tax_components
 
 # from payroll_indonesia.override.salary_slip.ter_calculator import calculate_monthly_pph_with_ter
 # from payroll_indonesia.override.salary_slip.gl_entry_override import make_gl_entries
@@ -535,7 +535,7 @@ def run_payroll_integration_tests():
         {
             "tests": [
                 {
-                    "module_name": "payroll_indonesia.tests.test_payroll_integration",
+                    "module_name": "payroll_indonesia.doctype.bpjs_payment_summary.test_bpjs_payment_summary",
                     "test_name": "TestPayrollIntegration",
                 }
             ]

--- a/payroll_indonesia/doctype/bpjs_payment_summary_detail/__init__.py
+++ b/payroll_indonesia/doctype/bpjs_payment_summary_detail/__init__.py
@@ -1,1 +1,2 @@
-# This file marks the golongan doctype directory as a Python package
+# Expose BPJS Payment Summary Detail tests
+from . import test_bpjs_payment_summary_detail  # noqa: F401

--- a/payroll_indonesia/doctype/bpjs_payment_summary_detail/test_bpjs_payment_summary_detail.py
+++ b/payroll_indonesia/doctype/bpjs_payment_summary_detail/test_bpjs_payment_summary_detail.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import unittest
+import pytest
+
+frappe = pytest.importorskip("frappe")
+
+from ...bpjs_payment_summary_detail import bpjs_payment_summary_detail as detail
+
+
+class TestBPJSPaymentSummaryDetail(unittest.TestCase):
+    def test_negative_amount_validation(self):
+        doc = frappe.get_doc({
+            "doctype": "BPJS Payment Summary Detail",
+            "employee": "EMP-TEST",
+            "amount": -1000,
+        })
+        with self.assertRaises(frappe.ValidationError):
+            doc.validate()
+


### PR DESCRIPTION
## Summary
- move BPJS integration tests under `bpjs_payment_summary`
- add basic tests for BPJS account mapping and summary detail
- expose tests via each doctype `__init__`
- remove old integration test file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e7e4393a88333882f5a6cfb836e46